### PR TITLE
Expand Functionality

### DIFF
--- a/lua/wire/stools/shipment_controller.lua
+++ b/lua/wire/stools/shipment_controller.lua
@@ -41,6 +41,10 @@ if CLIENT then
 	language.Add("tool.wire_shipment_controller.inputs", "Inputs")
 	language.Add("tool.wire_shipment_controller.outputs", "Outputs")
 	language.Add("tool.wire_shipment_controller.inputs.dispense", "[BOOLEAN 1/0] Dispenses 1 item from the shipment")
+	language.Add("tool.wire_shipment_controller.inputs.pricemarkup", "[NUMBER] Adds extra money to the price output")
+	language.Add("tool.wire_shipment_controller.inputs.seperatepricemarkup", "[NUMBER] Adds extra money to the seperate price output")
+	language.Add("tool.wire_shipment_controller.inputs.currency", "[STRING] Set the currency symbol")
+	language.Add("tool.wire_shipment_controller.inputs.outofstockmessage", "[STRING] The message to output when no shipment is detected")
 	language.Add("tool.wire_shipment_controller.outputs.quantity", "[NUMBER] Amount of items left in the shipment")
 	language.Add("tool.wire_shipment_controller.outputs.size", "[NUMBER] Amount of items the shipment originally held")
 	language.Add("tool.wire_shipment_controller.outputs.price", "[NUMBER] Price of shipment")
@@ -49,7 +53,9 @@ if CLIENT then
 	language.Add("tool.wire_shipment_controller.outputs.type", "[STRING] Class name of shipment item entity")
 	language.Add("tool.wire_shipment_controller.outputs.model", "[STRING] Model path of item")
 	language.Add("tool.wire_shipment_controller.outputs.separate", "[BOOLEAN 1/0] Whether the shipment is also sold separately")
-	language.Add("tool.wire_shipment_controller.outputs.separateprice", "[NUMBER] Price of item when sold separately")
+	language.Add("tool.wire_shipment_controller.outputs.separateprice", "[NUMBER] Price of item when sold separately, if not seperate the output will default to price / size")
+	language.Add("tool.wire_shipment_controller.outputs.nameandprice", "[STRING] Combination of name and price")
+	language.Add("tool.wire_shipment_controller.outputs.nameandprice", "[NUMBER] Combination of name and seperate price")
 	language.Add("tool.wire_shipment_controller.outputs.shipment", "[ENTITY] The shipment itself")
 
 	TOOL.Information = { { name = "left", text = "Create/Update " .. TOOL.Name } }
@@ -65,8 +71,8 @@ TOOL.ClientConVar = {
 if SERVER then
 	function TOOL:GetConVars() return self:GetClientNumber("range") end
 else
-	local inputs = { "Dispense" }
-	local outputs = { "Quantity", "Size", "Price", "Name", "Category", "Type", "Model", "Separate", "Separate Price", "Shipment" }
+	local inputs = { "Dispense", "Price Markup", "Seperate Price Markup", "Currency", "Out Of Stock Message" }
+	local outputs = { "Quantity", "Size", "Price", "Name", "Category", "Type", "Model", "Separate", "Separate Price", "Name And Price", "Name And Seperate Price", "Shipment" }
 
 	function TOOL.BuildCPanel(CPanel)
 		local link = CPanel:Help("https://github.com/WilliamVenner/wire_shipment_controller")


### PR DESCRIPTION
This pull requests expands on the functionality of this controller by:
- Changing the behaviour of Separate Price output
    - If Separate is false, default to `price / size` instead of `0`
- Adding four new inputs
    - Price Markup
       - Adds to the price output
    - Separate Price Markup
       - Adds to the separate price output
    - Currency
        -  Used in both new outputs, see below
    - Out Of Stock Message
        - Both new outputs will output this if no shipment is detected
- Adding two new outputs
    - Name and Price, format `{NAME} {CURRENCY}{PRICE}` eg `Gun $10000`
    - Name and Separate Price, format `{NAME} {CURRENCY}{SEPERATE PRICE}` eg `Gun $1000`
    
### Why Add This?
When using this controller in a gunshop with automatic gun pricing and out of stock indicators, it requires a lot of gates. (8 gates per controller)
These new functionality reduces it to 1 (the equal for triggering)

![Imgur](https://i.imgur.com/YmwxSFS.png)
![Imgur](https://i.imgur.com/0SkuojJ.png)